### PR TITLE
replace escape method with encodeURIComponent

### DIFF
--- a/vendor/assets/javascripts/ahoy.js
+++ b/vendor/assets/javascripts/ahoy.js
@@ -71,7 +71,7 @@
     if (domain) {
       cookieDomain = "; domain=" + domain;
     }
-    document.cookie = name + "=" + escape(value) + expires + cookieDomain + "; path=/";
+    document.cookie = name + "=" + encodeURIComponent(value) + expires + cookieDomain + "; path=/";
   }
 
   function getCookie(name) {


### PR DESCRIPTION
escape function was deprecated in JavaScript version 1.5. so we should use encodeURI() or encodeURIComponent() instead.
I got "URIError: URI malformed" for some languages like french, greek, spain etc
after replacing escape with encodeURIComponent() the issue has gone